### PR TITLE
Remove AWS region env var from API template

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,8 +234,9 @@ Before deploying, you must enable access to these Bedrock models in your AWS acc
 | `MODEL_ARN` | Claude model ARN | `arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0` | ✅ |
 | `GUARDRAIL_ID` | Bedrock Guardrail ID | `XXXXXXXXXX` | ✅ |
 | `GUARDRAIL_VERSION` | Guardrail version | `DRAFT` or `1` | ✅ |
-| `AWS_REGION` | AWS region | `us-east-1` | ✅ |
 | `NODE_ENV` | Environment | `development` or `production` | ❌ |
+
+> ℹ️ **Note:** AWS Lambda automatically provides the `AWS_REGION` environment variable at runtime, so no manual configuration is required.
 
 ### Infrastructure Variables (`infra/terraform.tfvars`)
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,5 +1,4 @@
 # Backend Environment Variables
-AWS_REGION=us-east-1
 KB_ID=your-knowledge-base-id
 MODEL_ARN=arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0
 GUARDRAIL_ID=your-guardrail-id


### PR DESCRIPTION
## Summary
- drop the AWS_REGION entry from the API environment template because Lambda provides it automatically
- update the backend environment variable documentation to remove AWS_REGION and explain the Lambda-provided value

## Testing
- ⚠️ `terraform init` *(fails: terraform binary is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e470faec83239acd23cb5ed6bcc9