### PR TITLE
Stop storing AWS region as a GitHub secret

### DIFF
--- a/.github/CICD.md
+++ b/.github/CICD.md
@@ -52,11 +52,13 @@ AWS_ROLE_ARN=arn:aws:iam::ACCOUNT-ID:role/GitHubActionsRole
 ```
 TF_VAR_PROJECT_NAME=fedrag
 TF_VAR_ENVIRONMENT=production|staging
-TF_VAR_AWS_REGION=us-east-1
 TF_VAR_COGNITO_DOMAIN_PREFIX=fedrag-prod
 TF_VAR_WEB_CALLBACK_URLS=["https://your-domain.com/callback"]
 TF_VAR_WEB_LOGOUT_URLS=["https://your-domain.com/login"]
 ```
+
+> ℹ️ **AWS Region:** Workflows use the region defined in your Terraform configuration (default `us-east-1`) or an override passed
+> through workflow inputs, so it does not need to be stored as a secret.
 
 ## AWS IAM Role Setup
 
@@ -105,8 +107,9 @@ Attach the following managed policies:
 2. Select "Deploy to Production" workflow
 3. Click "Run workflow"
 4. Choose environment (production/staging)
-5. Optionally skip tests for hotfixes
-6. **Manual approval required for production**
+5. (Optional) Override AWS region if different from your Terraform defaults
+6. Optionally skip tests for hotfixes
+7. **Manual approval required for production**
 
 ### Pull Request Process
 1. Create pull request

--- a/.github/environments/production.yml
+++ b/.github/environments/production.yml
@@ -24,7 +24,6 @@ secrets:
   # Terraform variables
   TF_VAR_PROJECT_NAME: "fedrag"
   TF_VAR_ENVIRONMENT: "production"
-  TF_VAR_AWS_REGION: "us-east-1"
   TF_VAR_COGNITO_DOMAIN_PREFIX: "fedrag-prod"
   TF_VAR_WEB_CALLBACK_URLS: '["https://your-domain.com/callback"]'
   TF_VAR_WEB_LOGOUT_URLS: '["https://your-domain.com/login"]'

--- a/.github/environments/staging.yml
+++ b/.github/environments/staging.yml
@@ -24,7 +24,6 @@ secrets:
   # Terraform variables
   TF_VAR_PROJECT_NAME: "fedrag"
   TF_VAR_ENVIRONMENT: "staging"
-  TF_VAR_AWS_REGION: "us-east-1"
   TF_VAR_COGNITO_DOMAIN_PREFIX: "fedrag-staging"
   TF_VAR_WEB_CALLBACK_URLS: '["https://staging.your-domain.com/callback"]'
   TF_VAR_WEB_LOGOUT_URLS: '["https://staging.your-domain.com/login"]'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,11 @@ on:
         options:
           - production
           - staging
+      aws_region:
+        description: 'AWS region for deployment (leave blank to use terraform.tfvars default)'
+        required: false
+        default: ''
+        type: string
       skip_tests:
         description: 'Skip tests and linting'
         required: false
@@ -98,16 +103,37 @@ jobs:
 
     outputs:
       plan-exists: ${{ steps.plan.outputs.plan-exists }}
+      aws-region: ${{ steps.determine-region.outputs.region }}
       
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Determine AWS region
+        id: determine-region
+        working-directory: infra
+        run: |
+          REGION="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.aws_region || '' }}"
+          if [ -z "$REGION" ]; then
+            REGION="${{ vars.AWS_REGION }}"
+          fi
+          if [ -z "$REGION" ] && [ -f terraform.tfvars ]; then
+            REGION=$(awk -F' *= *' '$1=="aws_region" { gsub(/"/, "", $2); print $2 }' terraform.tfvars | tail -n 1)
+          fi
+          if [ -z "$REGION" ] && [ -f terraform.tfvars.example ]; then
+            REGION=$(awk -F' *= *' '$1=="aws_region" { gsub(/"/, "", $2); print $2 }' terraform.tfvars.example | tail -n 1)
+          fi
+          if [ -z "$REGION" ]; then
+            REGION="us-east-1"
+          fi
+          echo "AWS_REGION=$REGION" >> $GITHUB_ENV
+          echo "region=$REGION" >> $GITHUB_OUTPUT
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
           role-session-name: GitHubActions-TerraformPlan
 
       - name: Setup Terraform
@@ -121,7 +147,7 @@ jobs:
           cat > terraform.tfvars << EOF
           project_name = "${{ secrets.TF_VAR_PROJECT_NAME }}"
           environment = "${{ inputs.environment || 'production' }}"
-          aws_region = "${{ secrets.TF_VAR_AWS_REGION }}"
+          aws_region = "${{ env.AWS_REGION }}"
           cognito_domain_prefix = "${{ secrets.TF_VAR_COGNITO_DOMAIN_PREFIX }}"
           web_callback_urls = ${{ secrets.TF_VAR_WEB_CALLBACK_URLS }}
           web_logout_urls = ${{ secrets.TF_VAR_WEB_LOGOUT_URLS }}
@@ -188,7 +214,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [terraform-plan, approval]
     if: always() && needs.terraform-plan.outputs.plan-exists == 'true' && needs.approval.result == 'success'
-    
+
     permissions:
       contents: read
       id-token: write
@@ -197,6 +223,10 @@ jobs:
       api-url: ${{ steps.outputs.outputs.api-url }}
       web-url: ${{ steps.outputs.outputs.web-url }}
       kb-id: ${{ steps.outputs.outputs.kb-id }}
+      aws-region: ${{ env.AWS_REGION }}
+
+    env:
+      AWS_REGION: ${{ needs.terraform-plan.outputs.aws-region }}
       
     steps:
       - name: Checkout code
@@ -206,7 +236,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
           role-session-name: GitHubActions-TerraformApply
 
       - name: Setup Terraform
@@ -227,7 +257,7 @@ jobs:
           cat > terraform.tfvars << EOF
           project_name = "${{ secrets.TF_VAR_PROJECT_NAME }}"
           environment = "${{ inputs.environment || 'production' }}"
-          aws_region = "${{ secrets.TF_VAR_AWS_REGION }}"
+          aws_region = "${{ env.AWS_REGION }}"
           cognito_domain_prefix = "${{ secrets.TF_VAR_COGNITO_DOMAIN_PREFIX }}"
           web_callback_urls = ${{ secrets.TF_VAR_WEB_CALLBACK_URLS }}
           web_logout_urls = ${{ secrets.TF_VAR_WEB_LOGOUT_URLS }}
@@ -268,17 +298,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [terraform-apply]
     if: always() && needs.terraform-apply.result == 'success'
-    
+
     permissions:
       contents: read
       id-token: write
+
+    env:
+      AWS_REGION: ${{ needs.terraform-apply.outputs.aws-region }}
       
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
           role-session-name: GitHubActions-FrontendDeploy
 
       - name: Download build artifacts
@@ -304,6 +337,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [terraform-apply, deploy-frontend]
     if: always() && needs.terraform-apply.result == 'success' && needs.deploy-frontend.result == 'success'
+
+    env:
+      AWS_REGION: ${{ needs.terraform-apply.outputs.aws-region }}
     
     steps:
       - name: Checkout code
@@ -313,7 +349,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
           role-session-name: GitHubActions-Validation
 
       - name: Run deployment validation
@@ -344,17 +380,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [terraform-apply, deploy-frontend, post-deployment]
     if: failure() && needs.terraform-apply.result == 'success'
-    
+
     permissions:
       contents: read
       id-token: write
+
+    env:
+      AWS_REGION: ${{ needs.terraform-apply.outputs.aws-region }}
       
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
           role-session-name: GitHubActions-Rollback
 
       - name: Notify of rollback

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -82,7 +82,7 @@ jobs:
     name: Terraform Plan
     runs-on: ubuntu-latest
     needs: lint-and-test
-    
+
     permissions:
       contents: read
       pull-requests: write
@@ -92,11 +92,26 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Determine AWS region
+        working-directory: infra
+        run: |
+          REGION="${{ vars.AWS_REGION }}"
+          if [ -z "$REGION" ] && [ -f terraform.tfvars ]; then
+            REGION=$(awk -F' *= *' '$1=="aws_region" { gsub(/"/, "", $2); print $2 }' terraform.tfvars | tail -n 1)
+          fi
+          if [ -z "$REGION" ] && [ -f terraform.tfvars.example ]; then
+            REGION=$(awk -F' *= *' '$1=="aws_region" { gsub(/"/, "", $2); print $2 }' terraform.tfvars.example | tail -n 1)
+          fi
+          if [ -z "$REGION" ]; then
+            REGION="us-east-1"
+          fi
+          echo "AWS_REGION=$REGION" >> $GITHUB_ENV
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
+          aws-region: ${{ env.AWS_REGION }}
           role-session-name: GitHubActions-TerraformPlan
 
       - name: Setup Terraform
@@ -110,7 +125,7 @@ jobs:
           cat > terraform.tfvars << EOF
           project_name = "${{ secrets.TF_VAR_PROJECT_NAME }}"
           environment = "${{ secrets.TF_VAR_ENVIRONMENT }}"
-          aws_region = "${{ secrets.TF_VAR_AWS_REGION }}"
+          aws_region = "${{ env.AWS_REGION }}"
           cognito_domain_prefix = "${{ secrets.TF_VAR_COGNITO_DOMAIN_PREFIX }}"
           web_callback_urls = ${{ secrets.TF_VAR_WEB_CALLBACK_URLS }}
           web_logout_urls = ${{ secrets.TF_VAR_WEB_LOGOUT_URLS }}

--- a/README.md
+++ b/README.md
@@ -338,11 +338,12 @@ Required GitHub Secrets:
 AWS_ROLE_ARN=arn:aws:iam::ACCOUNT:role/GitHubActionsRole
 TF_VAR_PROJECT_NAME=fedrag
 TF_VAR_ENVIRONMENT=production
-TF_VAR_AWS_REGION=us-east-1
 TF_VAR_COGNITO_DOMAIN_PREFIX=fedrag-prod
 TF_VAR_WEB_CALLBACK_URLS=["https://your-domain.com/callback"]
 TF_VAR_WEB_LOGOUT_URLS=["https://your-domain.com/login"]
 ```
+
+> ℹ️ **Region configuration:** The workflows resolve the AWS region from your `infra/terraform.tfvars` settings (defaulting to `us-east-1`) or an override provided via workflow inputs—no separate secret is required.
 
 ## 📚 Corpus Upload and Knowledge Base Sync
 


### PR DESCRIPTION
## Summary
- remove the TF_VAR_AWS_REGION entry from the documented GitHub secrets and note how the region is supplied
- update the deploy and PR workflows to resolve the AWS region from Terraform configuration or manual inputs instead of secrets
- propagate the chosen AWS region through dependent jobs and environment definitions so remaining secrets stay aligned with CI/CD needs

## Testing
- not run (documentation and workflow updates only)

------
https://chatgpt.com/codex/tasks/task_e_68c8eb23fc4c83238fe282358960913f