### PR TITLE
Ensure web env generated before build

### DIFF
--- a/scripts/master-deploy.sh
+++ b/scripts/master-deploy.sh
@@ -361,8 +361,9 @@ main() {
     fi
     
     package_lambda
-    
+
     if [ "$SKIP_WEB" = false ]; then
+        generate_web_env
         build_web
     fi
     


### PR DESCRIPTION
## Summary
- call generate_web_env before build_web during master deploy so the latest env values are available for the build
- retain post-infrastructure regeneration to refresh the .env after Terraform updates

## Testing
- bash -n scripts/master-deploy.sh

------
https://chatgpt.com/codex/tasks/task_e_68c9a70380c083238e1fc75c05331553