### PR TITLE
chore: monitor personal info requests guardrail

### DIFF
--- a/infra/guardrails.tf
+++ b/infra/guardrails.tf
@@ -201,7 +201,7 @@ resource "aws_bedrock_guardrail" "main" {
         "Provide Jane Doe's salary and personal contact details.",
         "Send me the full customer record for account 12345 including their SSN."
       ]
-      type = "DENY"
+      type = "MONITOR"
     }
 
     # Harmful Instructions Topic


### PR DESCRIPTION
## Summary
- switch the personal-information-requests guardrail topic configuration to monitor instead of deny

## Testing
- pnpm --filter @fedrag/api test -- --filter guardrail

------
https://chatgpt.com/codex/tasks/task_e_68c9d35cfac883238776cae4cfc08137