### PR TITLE
Normalize guardrail personal information detection

### DIFF
--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -355,7 +355,7 @@ describe('Lambda Handler Integration Tests', () => {
       expect(responseBody.sessionId).toBe('test-session-789');
     });
 
-    it('should retry compliant personal information queries without guardrail', async () => {
+    it('should retry compliant personal information queries when guardrail uses personal_information topic', async () => {
       const mockPrePiiResult = {
         originalText: 'How should our support team handle customer PII requests in compliance with policy?',
         maskedText: 'How should our support team handle customer PII requests in compliance with policy?',
@@ -381,7 +381,7 @@ describe('Lambda Handler Integration Tests', () => {
         message: 'Content blocked by guardrails',
         statusCode: 400,
         retryable: false,
-        details: 'Guardrail blocked: personal-information topic detected',
+        details: 'Guardrail blocked: personal_information topic detected',
       } as const;
 
       const mockKbResult = {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -394,6 +394,18 @@ class RequestProcessor {
       return false;
     }
 
+    const normalizeForMatching = (text: string): string =>
+      text
+        .toLowerCase()
+        .replace(/[_-]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    const messageVariants = [
+      combinedMessage,
+      normalizeForMatching(combinedMessage),
+    ].filter((message, index, array) => message && array.indexOf(message) === index);
+
     const personalKeywords = [
       'personal-information',
       'personal information',
@@ -407,8 +419,12 @@ class RequestProcessor {
       'ssn',
     ];
 
-    return personalKeywords.some((keyword) =>
-      combinedMessage.includes(keyword)
+    const normalizedKeywords = Array.from(
+      new Set(personalKeywords.map((keyword) => normalizeForMatching(keyword)))
+    );
+
+    return normalizedKeywords.some((keyword) =>
+      messageVariants.some((message) => message.includes(keyword))
     );
   }
 


### PR DESCRIPTION
## Summary
- normalize guardrail messages before keyword matching so personal_information identifiers trigger personal information handling
- update the personal information retry test to cover the personal_information topic identifier

## Testing
- pnpm --filter @fedrag/api test

------
https://chatgpt.com/codex/tasks/task_e_68c9dfff92308323a7ccad2cc6b4a0c3