### PR TITLE
feat(api): dynamic guardrail routing with compliance support

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,8 +232,10 @@ Before deploying, you must enable access to these Bedrock models in your AWS acc
 |----------|-------------|---------|----------|
 | `KB_ID` | Bedrock Knowledge Base ID | `XXXXXXXXXX` | ✅ |
 | `MODEL_ARN` | Claude model ARN | `arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0` | ✅ |
-| `GUARDRAIL_ID` | Bedrock Guardrail ID | `XXXXXXXXXX` | ✅ |
-| `GUARDRAIL_VERSION` | Guardrail version | `DRAFT` or `1` | ✅ |
+| `GR_DEFAULT_ID` | Primary Bedrock Guardrail ID | `XXXXXXXXXX` | ✅ |
+| `GR_DEFAULT_VERSION` | Primary guardrail version | `DRAFT` or `1` | ✅ |
+| `GR_COMPLIANCE_ID` | Compliance guardrail ID (used for compliant PII guidance) | `YYYYYYYYYY` | ✅ |
+| `GR_COMPLIANCE_VERSION` | Compliance guardrail version | `DRAFT` or `1` | ✅ |
 | `NODE_ENV` | Environment | `development` or `production` | ❌ |
 
 > ℹ️ **Note:** AWS Lambda automatically provides the `AWS_REGION` environment variable at runtime, so no manual configuration is required.

--- a/apps/api/src/safety/guardrailRouting.test.ts
+++ b/apps/api/src/safety/guardrailRouting.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  looksLikeCompliance,
+  chooseGuardrailId,
+  type GuardrailDefinitions,
+} from './guardrailRouting.js';
+
+const defaultGuardrails: GuardrailDefinitions = {
+  default: {
+    guardrailId: 'default-guardrail',
+    guardrailVersion: '1',
+  },
+  compliance: {
+    guardrailId: 'compliance-guardrail',
+    guardrailVersion: '2',
+  },
+};
+
+describe('guardrailRouting', () => {
+  describe('looksLikeCompliance', () => {
+    it('should detect compliance-oriented prompts with PII context keywords', () => {
+      const prompt = 'What compliance policies govern customer PII deletion requests?';
+      expect(looksLikeCompliance(prompt)).toBe(true);
+    });
+
+    it('should return false for non-compliance prompts', () => {
+      const prompt = 'Tell me about the weather tomorrow.';
+      expect(looksLikeCompliance(prompt)).toBe(false);
+    });
+  });
+
+  describe('chooseGuardrailId', () => {
+    it('should return default guardrail when compliance guardrail is not configured', async () => {
+      const detect = vi.fn().mockResolvedValue({ noneFound: true, entities: [] });
+
+      const selection = await chooseGuardrailId({
+        prompt: 'How do we ensure compliance with personal data policies?',
+        contextTexts: ['Follow the retention policy.'],
+        guardrails: { default: defaultGuardrails.default },
+        piiService: { detect } as any,
+      });
+
+      expect(selection.guardrail).toEqual(defaultGuardrails.default);
+      expect(selection.usedCompliance).toBe(false);
+      expect(detect).not.toHaveBeenCalled();
+    });
+
+    it('should select compliance guardrail when prompt is compliance oriented and no medium PII found', async () => {
+      const detect = vi.fn().mockResolvedValue({ noneFound: true, entities: [] });
+
+      const selection = await chooseGuardrailId({
+        prompt: 'How should we comply with policy when handling personal information?',
+        contextTexts: ['Always follow data protection processes.'],
+        guardrails: defaultGuardrails,
+        piiService: { detect } as any,
+      });
+
+      expect(selection.guardrail).toEqual(defaultGuardrails.compliance);
+      expect(selection.usedCompliance).toBe(true);
+      expect(detect).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fall back to default guardrail when medium PII is detected', async () => {
+      const detect = vi.fn().mockResolvedValue({
+        noneFound: false,
+        entities: [
+          { Type: 'SSN', Score: 0.9, BeginOffset: 10, EndOffset: 14 },
+        ],
+      });
+
+      const selection = await chooseGuardrailId({
+        prompt: 'How should we comply with policy when handling personal information?',
+        contextTexts: ['Employee SSN records must be encrypted.'],
+        guardrails: defaultGuardrails,
+        piiService: { detect } as any,
+      });
+
+      expect(selection.guardrail).toEqual(defaultGuardrails.default);
+      expect(selection.usedCompliance).toBe(false);
+      expect(detect).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return default guardrail for non-compliance prompts without calling detect', async () => {
+      const detect = vi.fn();
+
+      const selection = await chooseGuardrailId({
+        prompt: 'Summarize the company history.',
+        contextTexts: ['Founded in 1990.'],
+        guardrails: defaultGuardrails,
+        piiService: { detect } as any,
+      });
+
+      expect(selection.guardrail).toEqual(defaultGuardrails.default);
+      expect(selection.usedCompliance).toBe(false);
+      expect(detect).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/safety/guardrailRouting.ts
+++ b/apps/api/src/safety/guardrailRouting.ts
@@ -1,0 +1,152 @@
+import type { GuardrailConfiguration, PiiEntity } from "../types.js";
+import type { PiiDetectionResult, PiiService } from "../pii.js";
+
+const COMPLIANCE_REGEX = /(?=.*\b(?:compliance|comply|policy|policies|procedure|procedures|guideline|guidelines|requirement|requirements|regulation|regulations|standard|standards|allowed|permitted|how should|process|processes|governance)\b)(?=.*\b(?:pii|personal information|personal data|personally identifiable|sensitive data|customer data|data handling|data retention|data protection|privacy|data request|data requests|social security|ssn|phi)\b)/i;
+
+export function looksLikeCompliance(text: string): boolean {
+  if (!text) {
+    return false;
+  }
+
+  return COMPLIANCE_REGEX.test(text);
+}
+
+export interface GuardrailDefinitions {
+  default: GuardrailConfiguration;
+  compliance?: GuardrailConfiguration;
+}
+
+export interface GuardrailSelectionResult {
+  guardrail: GuardrailConfiguration;
+  usedCompliance: boolean;
+  detection?: PiiDetectionResult;
+}
+
+export interface ChooseGuardrailIdParams {
+  prompt: string;
+  contextTexts?: string[];
+  guardrails: GuardrailDefinitions;
+  piiService: Pick<PiiService, "detect">;
+  logger?: {
+    info?: (
+      message: string,
+      metadata?: Record<string, any>,
+      operation?: string,
+      duration?: number
+    ) => void;
+    debug?: (
+      message: string,
+      metadata?: Record<string, any>,
+      operation?: string,
+      duration?: number
+    ) => void;
+    warn?: (
+      message: string,
+      metadata?: Record<string, any>,
+      operation?: string,
+      duration?: number
+    ) => void;
+  };
+}
+
+const LOW_RISK_PII_TYPES = new Set([
+  "NAME",
+  "PERSON",
+  "TITLE",
+  "JOB_TITLE",
+  "ORGANIZATION",
+  "COMPANY",
+]);
+
+function hasMediumOrHighPii(entities: PiiEntity[]): boolean {
+  return entities.some((entity) => {
+    const type = entity.Type?.toUpperCase?.() ?? "";
+    return !LOW_RISK_PII_TYPES.has(type);
+  });
+}
+
+function buildCombinedText(prompt: string, contextTexts: string[] = []): string {
+  return [prompt, ...contextTexts]
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value))
+    .join("\n\n");
+}
+
+export async function chooseGuardrailId({
+  prompt,
+  contextTexts = [],
+  guardrails,
+  piiService,
+  logger,
+}: ChooseGuardrailIdParams): Promise<GuardrailSelectionResult> {
+  const complianceGuardrail = guardrails.compliance;
+
+  if (!complianceGuardrail) {
+    logger?.debug?.("Compliance guardrail unavailable; falling back to default", {
+      reason: "missing_compliance_guardrail",
+    });
+    return {
+      guardrail: guardrails.default,
+      usedCompliance: false,
+    };
+  }
+
+  if (!looksLikeCompliance(prompt)) {
+    logger?.debug?.("Prompt does not appear to request compliance guidance", {
+      reason: "non_compliance_prompt",
+    });
+    return {
+      guardrail: guardrails.default,
+      usedCompliance: false,
+    };
+  }
+
+  const combinedText = buildCombinedText(prompt, contextTexts);
+
+  if (!combinedText) {
+    logger?.info?.("Compliance guardrail selected with empty combined text", {
+      reason: "empty_combined_text",
+    });
+    return {
+      guardrail: complianceGuardrail,
+      usedCompliance: true,
+      detection: { noneFound: true, entities: [] },
+    };
+  }
+
+  try {
+    const detection = await piiService.detect(combinedText);
+    const containsMediumOrHigh = hasMediumOrHighPii(detection.entities);
+
+    if (!containsMediumOrHigh) {
+      logger?.info?.("Compliance guardrail selected after PII scan", {
+        reason: "no_medium_high_pii",
+        detectedEntities: detection.entities.length,
+      });
+      return {
+        guardrail: complianceGuardrail,
+        usedCompliance: true,
+        detection,
+      };
+    }
+
+    logger?.debug?.("Default guardrail retained due to detected PII", {
+      reason: "medium_high_pii_detected",
+      entityTypes: detection.entities.map((entity) => entity.Type),
+    });
+    return {
+      guardrail: guardrails.default,
+      usedCompliance: false,
+      detection,
+    };
+  } catch (error) {
+    logger?.warn?.("PII detection failed during guardrail selection; using default guardrail", {
+      reason: "pii_detection_failed",
+      error: (error as Error).message,
+    });
+    return {
+      guardrail: guardrails.default,
+      usedCompliance: false,
+    };
+  }
+}

--- a/apps/api/src/test-setup.ts
+++ b/apps/api/src/test-setup.ts
@@ -1,5 +1,7 @@
 // Set up environment variables for tests
 process.env.KB_ID = 'test-kb-id'
 process.env.MODEL_ARN = 'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0'
-process.env.GUARDRAIL_ID = 'test-guardrail-id'
-process.env.GUARDRAIL_VERSION = 'DRAFT'
+process.env.GR_DEFAULT_ID = 'test-guardrail-id'
+process.env.GR_DEFAULT_VERSION = 'DRAFT'
+process.env.GR_COMPLIANCE_ID = 'test-compliance-guardrail'
+process.env.GR_COMPLIANCE_VERSION = '1'

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -327,6 +327,8 @@ export interface LogEntry {
 export interface PerformanceMetrics {
   piiDetectionLatency?: number;
   knowledgeBaseLatency?: number;
+  contextRetrievalLatency?: number;
+  guardrailSelectionLatency?: number;
   totalLatency: number;
   guardrailInterventions: number;
   entitiesDetected: number;

--- a/infra/api.tf
+++ b/infra/api.tf
@@ -122,8 +122,10 @@ resource "aws_lambda_function" "api" {
       NODE_ENV          = var.environment
       KB_ID             = var.knowledge_base_id
       MODEL_ARN         = "arn:aws:bedrock:${data.aws_region.current.name}::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0"
-      GUARDRAIL_ID      = aws_bedrock_guardrail.main.guardrail_id
-      GUARDRAIL_VERSION = aws_bedrock_guardrail_version.main.version
+      GR_DEFAULT_ID     = aws_bedrock_guardrail.main.guardrail_id
+      GR_DEFAULT_VERSION = aws_bedrock_guardrail_version.main.version
+      GR_COMPLIANCE_ID   = aws_bedrock_guardrail.main.guardrail_id
+      GR_COMPLIANCE_VERSION = aws_bedrock_guardrail_version.main.version
       WEB_URL           = "https://${aws_cloudfront_distribution.web.domain_name}"
     }
   }


### PR DESCRIPTION
## Summary
- introduce guardrail routing utilities that detect compliance prompts and inspect context for medium/high PII before selecting the compliance guardrail
- extend the API request flow to retrieve context up front, choose the guardrail, and call Bedrock once with the selected configuration while exposing the new PII detect capability
- update Bedrock client, tests, documentation, and infrastructure variables to support per-request guardrail overrides and the new GR_* environment knobs

## Testing
- pnpm --filter @fedrag/api test

------
https://chatgpt.com/codex/tasks/task_e_68ca015477c48323953c268c6e9b3ae6