### PR TITLE
Add compliance guardrail and backoff test coverage

### DIFF
--- a/apps/api/tests/integration/complianceRouting.test.ts
+++ b/apps/api/tests/integration/complianceRouting.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { APIGatewayProxyEventV2, Context } from 'aws-lambda';
+
+import { handler } from '../../src/index.js';
+
+const knowledgeBaseMock = {
+  askKnowledgeBase: vi.fn(),
+  retrieveContext: vi.fn(),
+};
+
+vi.mock('../../src/services/knowledgeBase.js', () => ({
+  KnowledgeBaseService: vi.fn().mockImplementation(() => knowledgeBaseMock),
+}));
+
+vi.mock('../../src/bedrock.js', () => ({
+  createBedrockKnowledgeBase: vi.fn().mockReturnValue({}),
+  isGuardrailIntervention: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('../../src/pii.js', () => ({
+  PiiService: vi.fn(),
+}));
+
+vi.mock('../../src/telemetry/log.js', () => ({
+  emitRequestTelemetry: vi.fn(),
+}));
+
+import { PiiService } from '../../src/pii.js';
+import { emitRequestTelemetry } from '../../src/telemetry/log.js';
+
+describe('Compliance routing integration', () => {
+  let mockPiiService: { redactPII: ReturnType<typeof vi.fn>; detect: ReturnType<typeof vi.fn> };
+  let context: Context;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    knowledgeBaseMock.askKnowledgeBase.mockReset();
+    knowledgeBaseMock.retrieveContext.mockReset();
+
+    mockPiiService = {
+      redactPII: vi.fn(),
+      detect: vi.fn(),
+    };
+    (PiiService as unknown as vi.Mock).mockImplementation(() => mockPiiService);
+
+    Object.assign(process.env, {
+      KB_ID: 'test-kb-id',
+      MODEL_ARN:
+        'arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-3-5-sonnet-20240620-v1:0',
+      GR_DEFAULT_ID: 'test-guardrail-id',
+      GR_DEFAULT_VERSION: '1',
+      GR_COMPLIANCE_ID: 'test-compliance-guardrail',
+      GR_COMPLIANCE_VERSION: '1',
+      AWS_REGION: 'us-east-1',
+      LOG_LEVEL: 'DEBUG',
+    });
+
+    knowledgeBaseMock.retrieveContext.mockResolvedValue({
+      snippets: ['Refer to the official retention schedule.'],
+      metadata: { retryCount: 0, cacheHit: false, degraded: false },
+    });
+
+    knowledgeBaseMock.askKnowledgeBase.mockResolvedValue({
+      output: { text: 'Default knowledge base response.' },
+      citations: [],
+      guardrailAction: 'NONE',
+      sessionId: 'session-123',
+      metadata: { retryCount: 0, cacheHit: false, degraded: false },
+    });
+
+    context = {
+      awsRequestId: 'test-request-id',
+      callbackWaitsForEmptyEventLoop: false,
+      functionName: 'test-function',
+      functionVersion: '1',
+      invokedFunctionArn:
+        'arn:aws:lambda:us-east-1:123456789012:function:test-function',
+      memoryLimitInMB: '128',
+      logGroupName: '/aws/lambda/test-function',
+      logStreamName: '2024/01/01/[$LATEST]test-stream',
+      getRemainingTimeInMillis: () => 30000,
+      done: vi.fn(),
+      fail: vi.fn(),
+      succeed: vi.fn(),
+    } as unknown as Context;
+  });
+
+  afterEach(() => {
+    delete process.env.KB_ID;
+    delete process.env.MODEL_ARN;
+    delete process.env.GR_DEFAULT_ID;
+    delete process.env.GR_DEFAULT_VERSION;
+    delete process.env.GR_COMPLIANCE_ID;
+    delete process.env.GR_COMPLIANCE_VERSION;
+    delete process.env.AWS_REGION;
+    delete process.env.LOG_LEVEL;
+  });
+
+  function createEvent(query: string, sessionId = 'session-123'): APIGatewayProxyEventV2 {
+    return {
+      version: '2.0',
+      routeKey: 'POST /chat',
+      rawPath: '/chat',
+      rawQueryString: '',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost:3000',
+        'user-agent': 'vitest',
+      },
+      requestContext: {
+        accountId: '123456789012',
+        apiId: 'test-api',
+        domainName: 'example.com',
+        domainPrefix: 'example',
+        http: {
+          method: 'POST',
+          path: '/chat',
+          protocol: 'HTTP/1.1',
+          sourceIp: '127.0.0.1',
+          userAgent: 'vitest',
+        },
+        requestId: 'test-request',
+        routeKey: 'POST /chat',
+        stage: 'test',
+        time: new Date().toISOString(),
+        timeEpoch: Date.now(),
+      },
+      body: JSON.stringify({ query, sessionId }),
+      isBase64Encoded: false,
+      cookies: [],
+      queryStringParameters: null,
+      pathParameters: null,
+      stageVariables: null,
+      multiValueHeaders: undefined,
+    } as unknown as APIGatewayProxyEventV2;
+  }
+
+  it('routes compliance prompts through the compliance guardrail with a single Bedrock invocation', async () => {
+    const query =
+      'Which compliance policies govern retention of customer PII records?';
+
+    mockPiiService.redactPII
+      .mockResolvedValueOnce({
+        originalText: query,
+        maskedText: query,
+        entitiesFound: [],
+      })
+      .mockResolvedValueOnce({
+        originalText: 'Compliance guidance response.',
+        maskedText: 'Compliance guidance response.',
+        entitiesFound: [],
+      });
+
+    mockPiiService.detect.mockResolvedValue({ noneFound: true, entities: [] });
+
+    const event = createEvent(query);
+    const result = await handler(event, context);
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.answer).toBe('Compliance guidance response.');
+
+    expect(knowledgeBaseMock.askKnowledgeBase).toHaveBeenCalledTimes(1);
+    expect(knowledgeBaseMock.retrieveContext).toHaveBeenCalledTimes(1);
+
+    const askArgs = knowledgeBaseMock.askKnowledgeBase.mock.calls[0][0];
+    expect(askArgs.guardrail).toEqual({
+      guardrailId: 'test-compliance-guardrail',
+      guardrailVersion: '1',
+    });
+    expect(askArgs.intent).toBe('compliance');
+
+    expect(mockPiiService.detect).toHaveBeenCalledTimes(1);
+    expect(emitRequestTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guardrailId: 'test-compliance-guardrail',
+        isCompliance: true,
+      })
+    );
+  });
+
+  it('propagates knowledge base throttling as a degraded result', async () => {
+    const query = 'Provide the retention schedule for archived customer data.';
+
+    mockPiiService.redactPII
+      .mockResolvedValueOnce({
+        originalText: query,
+        maskedText: query,
+        entitiesFound: [],
+      })
+      .mockResolvedValueOnce({
+        originalText:
+          "I'm temporarily unable to retrieve verified knowledge base sources due to throttling.",
+        maskedText:
+          "I'm temporarily unable to retrieve verified knowledge base sources due to throttling.",
+        entitiesFound: [],
+      });
+
+    mockPiiService.detect.mockResolvedValue({ noneFound: true, entities: [] });
+
+    knowledgeBaseMock.askKnowledgeBase.mockResolvedValue({
+      output: {
+        text: "I'm temporarily unable to retrieve verified knowledge base sources due to throttling.",
+      },
+      citations: [],
+      guardrailAction: 'NONE',
+      sessionId: 'session-degraded',
+      metadata: { retryCount: 2, cacheHit: false, degraded: true },
+      error: { name: 'ThrottlingException', statusCode: 429 },
+    });
+
+    const event = createEvent(query);
+    const result = await handler(event, context);
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.citations).toEqual([]);
+    expect(body.guardrailAction).toBe('NONE');
+    expect(body.answer).toContain('temporarily unable');
+
+    expect(emitRequestTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({ kbDegraded: true })
+    );
+  });
+
+  it('keeps high risk PII prompts on the default guardrail and returns masked output', async () => {
+    const query =
+      'Which compliance controls cover employee SSN 123-45-6789 when offboarding?';
+
+    mockPiiService.redactPII
+      .mockResolvedValueOnce({
+        originalText: query,
+        maskedText:
+          'Which compliance controls cover employee <REDACTED:PERSON> SSN <REDACTED:SSN> when offboarding?',
+        entitiesFound: [
+          { Type: 'PERSON', Score: 0.8 },
+          { Type: 'SSN', Score: 0.95 },
+        ],
+      })
+      .mockResolvedValueOnce({
+        originalText: 'Ensure SSN 123-45-6789 is removed from all records.',
+        maskedText: 'Ensure SSN <REDACTED:SSN> is removed from all records.',
+        entitiesFound: [{ Type: 'SSN', Score: 0.9 }],
+      });
+
+    mockPiiService.detect.mockResolvedValue({
+      noneFound: false,
+      entities: [
+        { Type: 'SSN', Score: 0.95, BeginOffset: 48, EndOffset: 59 },
+      ],
+    });
+
+    knowledgeBaseMock.askKnowledgeBase.mockResolvedValue({
+      output: { text: 'Ensure SSN 123-45-6789 is removed from all records.' },
+      citations: [],
+      guardrailAction: 'NONE',
+      sessionId: 'session-ssn',
+      metadata: { retryCount: 0, cacheHit: false, degraded: false },
+    });
+
+    const event = createEvent(query, 'session-ssn');
+    const result = await handler(event, context);
+
+    expect(result.statusCode).toBe(200);
+    const body = JSON.parse(result.body);
+    expect(body.answer).toBe(
+      'Ensure SSN <REDACTED:SSN> is removed from all records.'
+    );
+    expect(body.redactedAnswer).toBe(
+      'Ensure SSN <REDACTED:SSN> is removed from all records.'
+    );
+    expect(body.redactedQuery).toBe(
+      'Which compliance controls cover employee <REDACTED:PERSON> SSN <REDACTED:SSN> when offboarding?'
+    );
+
+    const askArgs = knowledgeBaseMock.askKnowledgeBase.mock.calls[0][0];
+    expect(askArgs.guardrail).toEqual({
+      guardrailId: 'test-guardrail-id',
+      guardrailVersion: '1',
+    });
+    expect(askArgs.intent).toBe('default');
+
+    expect(mockPiiService.detect).toHaveBeenCalledTimes(1);
+    expect(mockPiiService.detect.mock.calls[0][0]).toContain('123-45-6789');
+    expect(emitRequestTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({ isCompliance: false })
+    );
+  });
+});

--- a/apps/api/tests/unit/lib/backoff.test.ts
+++ b/apps/api/tests/unit/lib/backoff.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import { withBackoff } from '../../../src/lib/backoff.js';
+
+describe('withBackoff', () => {
+  it('retries a failing operation until it succeeds when the error is retryable', async () => {
+    const operation = vi
+      .fn<[], Promise<string>>()
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValue('success');
+
+    const shouldRetry = vi.fn().mockReturnValue(true);
+
+    const result = await withBackoff(operation, {
+      maxRetries: 3,
+      baseDelayMs: 0,
+      maxDelayMs: 0,
+      shouldRetry,
+    });
+
+    expect(result).toEqual({ result: 'success', retries: 1 });
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(shouldRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws the last error with the retry count when retries are exhausted', async () => {
+    const terminalError = new Error('persistent failure');
+    const operation = vi.fn<[], Promise<string>>().mockRejectedValue(terminalError);
+    const shouldRetry = vi.fn().mockReturnValue(true);
+
+    await expect(
+      withBackoff(operation, {
+        maxRetries: 2,
+        baseDelayMs: 0,
+        maxDelayMs: 0,
+        shouldRetry,
+      })
+    ).rejects.toBe(terminalError);
+
+    expect(operation).toHaveBeenCalledTimes(3);
+    expect(shouldRetry).toHaveBeenCalledTimes(3);
+    expect((terminalError as any).retries).toBe(2);
+  });
+});

--- a/apps/api/tests/unit/safety/guardrailRouting.test.ts
+++ b/apps/api/tests/unit/safety/guardrailRouting.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  looksLikeCompliance,
+  chooseGuardrailId,
+  type GuardrailDefinitions,
+} from '../../../src/safety/guardrailRouting.js';
+
+describe('looksLikeCompliance', () => {
+  it('identifies prompts that reference policies and PII concerns', () => {
+    const prompt =
+      'Which compliance policies govern how we process customer PII requests?';
+
+    expect(looksLikeCompliance(prompt)).toBe(true);
+  });
+
+  it('returns false for non-compliance related prompts', () => {
+    const prompt = 'What will the weather be like tomorrow in Seattle?';
+
+    expect(looksLikeCompliance(prompt)).toBe(false);
+  });
+});
+
+describe('chooseGuardrailId', () => {
+  const guardrails: GuardrailDefinitions = {
+    default: { guardrailId: 'default-guardrail', guardrailVersion: '1' },
+    compliance: {
+      guardrailId: 'compliance-guardrail',
+      guardrailVersion: '2',
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the compliance guardrail when the prompt looks like a compliance request and no medium/high PII is found', async () => {
+    const detect = vi
+      .fn()
+      .mockResolvedValue({ noneFound: true, entities: [] });
+
+    const result = await chooseGuardrailId({
+      prompt: 'How should we comply with policy when handling customer PII?',
+      contextTexts: ['Refer to the official retention procedures.'],
+      guardrails,
+      piiService: { detect } as any,
+    });
+
+    expect(result.usedCompliance).toBe(true);
+    expect(result.guardrail).toEqual(guardrails.compliance);
+    expect(detect).toHaveBeenCalledTimes(1);
+    expect(detect.mock.calls[0][0]).toContain('customer PII');
+    expect(detect.mock.calls[0][0]).toContain('retention procedures');
+  });
+
+  it('falls back to the default guardrail when PII scan finds medium or high risk entities', async () => {
+    const detect = vi.fn().mockResolvedValue({
+      noneFound: false,
+      entities: [
+        { Type: 'SSN', Score: 0.9, BeginOffset: 10, EndOffset: 21 },
+        { Type: 'NAME', Score: 0.7, BeginOffset: 30, EndOffset: 40 },
+      ],
+    });
+
+    const result = await chooseGuardrailId({
+      prompt:
+        'Which compliance standards apply when storing an employee SSN securely?',
+      contextTexts: ['SSNs must be encrypted both at rest and in transit.'],
+      guardrails,
+      piiService: { detect } as any,
+    });
+
+    expect(result.usedCompliance).toBe(false);
+    expect(result.guardrail).toEqual(guardrails.default);
+    expect(detect).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips PII detection and returns the default guardrail for non-compliance prompts', async () => {
+    const detect = vi.fn();
+
+    const result = await chooseGuardrailId({
+      prompt: 'Summarize the company mission statement.',
+      contextTexts: ['Founded in 1999 with a focus on analytics.'],
+      guardrails,
+      piiService: { detect } as any,
+    });
+
+    expect(result.usedCompliance).toBe(false);
+    expect(result.guardrail).toEqual(guardrails.default);
+    expect(detect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add safety guardrail unit tests covering compliance detection and guardrail routing decisions
- add withBackoff retry unit tests for successful retry and exhausted failure scenarios
- add mocked integration tests that exercise compliance routing, throttling degradation, and PII fallback behavior

## Testing
- pnpm --filter @fedrag/api test

------
https://chatgpt.com/codex/tasks/task_e_68ca16785db48323900ff33b0d634864