### PR TITLE
Allow warn/error/debug logs to include duration parameter

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -157,26 +157,29 @@ class Logger {
   warn(
     message: string,
     metadata?: Record<string, any>,
-    operation?: string
+    operation?: string,
+    duration?: number
   ): void {
-    this.log("WARN", message, metadata, operation);
+    this.log("WARN", message, metadata, operation, duration);
   }
 
   error(
     message: string,
     metadata?: Record<string, any>,
-    operation?: string
+    operation?: string,
+    duration?: number
   ): void {
-    this.log("ERROR", message, metadata, operation);
+    this.log("ERROR", message, metadata, operation, duration);
   }
 
   debug(
     message: string,
     metadata?: Record<string, any>,
-    operation?: string
+    operation?: string,
+    duration?: number
   ): void {
     if (this.logLevel === "DEBUG") {
-      this.log("DEBUG", message, metadata, operation);
+      this.log("DEBUG", message, metadata, operation, duration);
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow structured Logger.warn, .error, and .debug helpers to accept optional duration values
- forward provided durations to the core logger to support metrics-aware callers

## Testing
- pnpm --filter @fedrag/api type-check

------
https://chatgpt.com/codex/tasks/task_e_68ca1de36bec8323b1f9a41ed4161e81