### PR TITLE
fix: remove unnecessary regex escapes

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -807,12 +807,12 @@ class RequestProcessor {
     };
 
     for (const match of normalized.matchAll(
-      /topics?(?: detected| hit| flagged| found| triggered)?[:\s]+([a-z0-9\-\/ ,]+)/g
+      /topics?(?: detected| hit| flagged| found| triggered)?[:\s]+([-a-z0-9/ ,]+)/g
     )) {
       collect(match[1]);
     }
 
-    for (const match of normalized.matchAll(/([a-z0-9][a-z0-9\-\/ ]+?)\s+topic(?:s)?/g)) {
+    for (const match of normalized.matchAll(/([a-z0-9][-a-z0-9/ ]+?)\s+topic(?:s)?/g)) {
       collect(match[1]);
     }
 


### PR DESCRIPTION
## Summary
- remove unnecessary escaping of forward slashes in topic extraction regular expressions to satisfy eslint's no-useless-escape rule

## Testing
- pnpm --filter @fedrag/api lint

------
https://chatgpt.com/codex/tasks/task_e_68ca27f814948323b8deab383030767d